### PR TITLE
Add breakpoint and media query

### DIFF
--- a/src/sections/challenges.scss
+++ b/src/sections/challenges.scss
@@ -6,7 +6,11 @@
     h2 {
         text-align: center;
     }
+    @media (min-width: $bp-xlarge){
+        max-width: 1650px;
+    }
 }
+
 
 .challenge-list {
     display: flex;

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -1,5 +1,6 @@
 $bp-medium: 600px;
 $bp-large: 1000px;
+$bp-xlarge: 1675px;
 $c-darkblue: #021928;
 $c-blue: #36769d;
 $c-lightblue: #8acfe5;

--- a/static/main.css
+++ b/static/main.css
@@ -314,6 +314,11 @@ header h1 {
 .challenges h2 {
   text-align: center;
 }
+@media (min-width: 1675px) {
+  .challenges {
+    max-width: 1650px;
+  }
+}
 
 .challenge-list {
   display: flex;
@@ -657,15 +662,12 @@ footer a:hover {
 }
 
 .starBar > label {
-
-
   margin: 0 1px 0 1px;
   width: 12px;
   height: 12px;
   font-size: 12px;
-  color: #E3170A;
+  color: #e3170a;
   font-family: "Font Awesome 6 Free";
-
 }
 
 .starBar label::before {

--- a/static/main.css
+++ b/static/main.css
@@ -666,7 +666,7 @@ footer a:hover {
   width: 12px;
   height: 12px;
   font-size: 12px;
-  color: #e3170a;
+  color: #E3170A;
   font-family: "Font Awesome 6 Free";
 }
 


### PR DESCRIPTION
La till breakpoint för skärmar över 1675px där max-width sätts till 1650px.

Man hade kunnat nå samma resultat genom att bara ta bort max-width i `.challenges` vilket får att cardsen wrappar av sig själv oberoende av skärmbredd. Men jag valde den mer kontrollerade lösningen då kunden inte specifierat att den vill ha fler än 4 cards. 

![fourcardsbigscreen](https://user-images.githubusercontent.com/97404672/207556335-e1e9c7bb-0df7-4521-9a18-c964a470bca1.png)
