### PR TITLE
remove console.log

### DIFF
--- a/API/String.js
+++ b/API/String.js
@@ -1,19 +1,17 @@
 export default class String {
-    static abbreviateTo(maxLength, str) {
-      if (str.length > Number(maxLength)) {
-        const lastSpace = str.lastIndexOf(" ");
-        const newStr = str.slice(0, lastSpace);
-  
-        if (newStr.length > Number(maxLength)) {
-          console.log(newStr);
-          return this.abbreviateTo(maxLength, newStr);
-        } else {
-          return newStr + "...";
-        }
-  
+  static abbreviateTo(maxLength, str) {
+    if (str.length > Number(maxLength)) {
+      const lastSpace = str.lastIndexOf(" ");
+      const newStr = str.slice(0, lastSpace);
+
+      if (newStr.length > Number(maxLength)) {
+        return this.abbreviateTo(maxLength, newStr);
       } else {
-        return str;
+        return newStr + "...";
       }
+      
+    } else {
+      return str;
     }
   }
-  
+}


### PR DESCRIPTION
Jag hade glömt att ta bort console.log när jag utvecklade funktionen. Console.log-spammen upptäcktes av Alvar när han testade appen efter att mergen hade gått igenom. Raden som innehöll console.log() är nu borttagen.